### PR TITLE
Otimizar funil de vendas

### DIFF
--- a/BaseDeProjetos/Controllers/FunilDeVendasController.cs
+++ b/BaseDeProjetos/Controllers/FunilDeVendasController.cs
@@ -29,8 +29,8 @@ namespace BaseDeProjetos.Controllers
         }
 
         // GET: FunilDeVendas
-        [Route("FunilDeVendas/Index/{casa?}/{ano?}")]
-        public IActionResult Index(string casa, string sortOrder = "", string searchString = "", string ano = "")
+        [Route("FunilDeVendas/Index/{casa?}/{aba?}/{ano?}")]
+        public IActionResult Index(string casa, string aba, string sortOrder = "", string searchString = "", string ano = "")
         {
             if (HttpContext.User.Identity.IsAuthenticated)
             {
@@ -45,15 +45,20 @@ namespace BaseDeProjetos.Controllers
                 }
 
                 List<Empresa> empresas = _context.Empresa.ToList();
-                List<Prospeccao> lista;
-                lista = FunilHelpers.DefinirCasaParaVisualizar(casa, usuario, _context, HttpContext, ViewData);
-                lista = FunilHelpers.VincularCasaProspeccao(usuario, lista);
-                lista = FunilHelpers.PeriodizarProspecções(ano, lista); // ANO DA PROSPEC
-                lista = FunilHelpers.OrdenarProspecções(sortOrder, lista); //SORT ORDEM ALFABETICA
-                lista = FunilHelpers.FiltrarProspecções(searchString, lista); //APENAS NA BUSCA
+                List<Prospeccao> prospeccoes;
+                prospeccoes = FunilHelpers.DefinirCasaParaVisualizar(casa, usuario, _context, HttpContext, ViewData);
+                prospeccoes = FunilHelpers.VincularCasaProspeccao(usuario, prospeccoes);
+                prospeccoes = FunilHelpers.PeriodizarProspecções(ano, prospeccoes); // ANO DA PROSPEC
+                prospeccoes = FunilHelpers.OrdenarProspecções(sortOrder, prospeccoes); //SORT ORDEM ALFABETICA
+                prospeccoes = FunilHelpers.FiltrarProspecções(searchString, prospeccoes); // APENAS NA BUSCA
                 FunilHelpers.SetarFiltrosNaView(HttpContext, ViewData, sortOrder, searchString);
-                FunilHelpers.CategorizarProspecçõesNaView(lista, usuario, HttpContext, ViewBag);
-                ViewData["ListaProspeccoes"] = lista.ToList();
+
+                if (!string.IsNullOrEmpty(aba))
+                {
+                    FunilHelpers.CategorizarProspecçõesNaView(prospeccoes, usuario, aba, HttpContext, ViewBag);
+                }
+                
+                ViewData["ListaProspeccoes"] = prospeccoes.ToList();
                 ViewData["Empresas"] = new SelectList(empresas, "Id", "EmpresaUnique");
                 ViewData["Equipe"] = new SelectList(_context.Users.ToList(), "Id", "UserName");
 

--- a/BaseDeProjetos/Helpers/FunilHelpers.cs
+++ b/BaseDeProjetos/Helpers/FunilHelpers.cs
@@ -111,29 +111,44 @@ namespace BaseDeProjetos.Helpers
             }
         }
 
-        public static void CategorizarProspecçõesNaView(List<Prospeccao> lista, Usuario usuario, HttpContext HttpContext, dynamic ViewBag)
+        public static void CategorizarProspecçõesNaView(List<Prospeccao> lista, Usuario usuario, string aba, HttpContext HttpContext, dynamic ViewBag)
         {
 
-            List<Prospeccao> concluidos = lista.Where(prospeccao => prospeccao.Status.Any(followup => followup.Status == StatusProspeccao.Convertida ||
+            if (aba.ToLower() == "ativas") 
+            {
+                List<Prospeccao> ativas = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status < StatusProspeccao.ComProposta).ToList();
+                ViewBag.Ativas = ativas;
+            }
+            else if (aba.ToLower() == "comproposta")
+            {
+                List<Prospeccao> emProposta = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status == StatusProspeccao.ComProposta).ToList();
+                ViewBag.EmProposta = emProposta;
+            } 
+            else if (aba.ToLower() == "concluidas")
+            {
+                List<Prospeccao> concluidas = lista.Where(prospeccao => prospeccao.Status.Any(followup => followup.Status == StatusProspeccao.Convertida ||
                                                               followup.Status == StatusProspeccao.Suspensa ||
                                                               followup.Status == StatusProspeccao.NaoConvertida)).ToList();
-
-            List<Prospeccao> errados = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.ContatoInicial
-            && prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.Planejada).ToList();
-
-            List<Prospeccao> emProposta = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status == StatusProspeccao.ComProposta).ToList();
-
-            List<Prospeccao> ativos = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status < StatusProspeccao.ComProposta).ToList();
-
-            List<Prospeccao> planejados = usuario.Nivel == Nivel.Dev ?
-            lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).ToList() :
-            lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).Where(prosp => prosp.Usuario.UserName.ToString() == HttpContext.User.Identity.Name).ToList();
-
-            ViewBag.Erradas = errados;
-            ViewBag.Concluidas = concluidos;
-            ViewBag.Ativas = ativos;
-            ViewBag.EmProposta = emProposta;
-            ViewBag.Planejadas = planejados;
+                ViewBag.Concluidas = concluidas;
+            } 
+            else if (aba.ToLower() == "planejadas")
+            {
+                // Jesus cristo 😬
+                List<Prospeccao> planejadas = usuario.Nivel == Nivel.Dev ?
+                            lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).ToList() :
+                            lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).Where(prosp => prosp.Usuario.UserName.ToString() == HttpContext.User.Identity.Name).ToList();
+                ViewBag.Planejadas = planejadas;
+            } 
+            else if (aba.ToLower() == "erradas")
+            {
+                List<Prospeccao> erradas = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.ContatoInicial
+                            && prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.Planejada).ToList();
+                ViewBag.Erradas = erradas;
+            } 
+            else
+            {
+                return;
+            }            
         }
 
         public static List<Prospeccao> DefinirCasaParaVisualizar(string? casa, Usuario usuario, ApplicationDbContext _context, HttpContext HttpContext, ViewDataDictionary ViewData)

--- a/BaseDeProjetos/Helpers/FunilHelpers.cs
+++ b/BaseDeProjetos/Helpers/FunilHelpers.cs
@@ -114,24 +114,24 @@ namespace BaseDeProjetos.Helpers
         public static void CategorizarProspecçõesNaView(List<Prospeccao> lista, Usuario usuario, string aba, HttpContext HttpContext, dynamic ViewBag)
         {
 
-            if (aba.ToLower() == "ativas") 
+            if (aba.ToLowerInvariant() == "ativas") 
             {
                 List<Prospeccao> ativas = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status < StatusProspeccao.ComProposta).ToList();
                 ViewBag.Ativas = ativas;
             }
-            else if (aba.ToLower() == "comproposta")
+            else if (aba.ToLowerInvariant() == "comproposta")
             {
                 List<Prospeccao> emProposta = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status == StatusProspeccao.ComProposta).ToList();
                 ViewBag.EmProposta = emProposta;
             } 
-            else if (aba.ToLower() == "concluidas")
+            else if (aba.ToLowerInvariant() == "concluidas")
             {
                 List<Prospeccao> concluidas = lista.Where(prospeccao => prospeccao.Status.Any(followup => followup.Status == StatusProspeccao.Convertida ||
                                                               followup.Status == StatusProspeccao.Suspensa ||
                                                               followup.Status == StatusProspeccao.NaoConvertida)).ToList();
                 ViewBag.Concluidas = concluidas;
             } 
-            else if (aba.ToLower() == "planejadas")
+            else if (aba.ToLowerInvariant() == "planejadas")
             {
                 // Jesus cristo 😬
                 List<Prospeccao> planejadas = usuario.Nivel == Nivel.Dev ?
@@ -139,7 +139,7 @@ namespace BaseDeProjetos.Helpers
                             lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).Where(prosp => prosp.Usuario.UserName.ToString() == HttpContext.User.Identity.Name).ToList();
                 ViewBag.Planejadas = planejadas;
             } 
-            else if (aba.ToLower() == "erradas")
+            else if (aba.ToLowerInvariant() == "erradas")
             {
                 List<Prospeccao> erradas = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.ContatoInicial
                             && prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.Planejada).ToList();

--- a/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
@@ -2,12 +2,43 @@
 @using Microsoft.AspNetCore.Http;
 @{
 	ViewData["Title"] = "Funil de Vendas";
-	List<Prospeccao> ativas = ViewBag.Ativas as List<Prospeccao>;
-	List<Prospeccao> propostas = ViewBag.EmProposta as List<Prospeccao>;
-	List<Prospeccao> concluidas = ViewBag.Concluidas as List<Prospeccao>;
-	List<Prospeccao> planejadas = ViewBag.Planejadas as List<Prospeccao>;
-	List<Prospeccao> erradas = ViewBag.Erradas as List<Prospeccao>;
-	List<Instituto> institutos = new List<Instituto>((Instituto[])Enum.GetValues(typeof(Instituto))).Where(c => c != Instituto.Super).ToList();
+
+	var dadosDaRota = ViewContext.RouteData;
+	string aba = dadosDaRota.Values["aba"] as string;
+	string casa = dadosDaRota.Values["casa"] as string;
+	//aba = aba.ToLowerInvariant(); // Safeguard
+
+	List<Prospeccao> ativas = new List<Prospeccao>();
+	List<Prospeccao> comproposta = new List<Prospeccao>();
+	List<Prospeccao> concluidas = new List<Prospeccao>();
+	List<Prospeccao> erradas = new List<Prospeccao>();
+	List<Prospeccao> planejadas = new List<Prospeccao>();
+
+	if (!string.IsNullOrEmpty(aba))
+	{
+		if (aba.ToLowerInvariant() == "ativas")
+		{
+			ativas = ViewBag.Ativas as List<Prospeccao>;
+		}
+		else if (aba.ToLowerInvariant() == "comproposta")
+		{
+			comproposta = ViewBag.EmProposta as List<Prospeccao>;
+		}
+		else if (aba.ToLowerInvariant() == "concluidas")
+		{
+			concluidas = ViewBag.Concluidas as List<Prospeccao>;
+		} 
+		else if (aba.ToLowerInvariant() == "erradas")
+		{
+			erradas = ViewBag.Erradas as List<Prospeccao>;
+		}
+		else if (aba.ToLowerInvariant() == "planejadas")
+		{
+			planejadas = ViewBag.Planejadas as List<Prospeccao>;
+		}
+	}	
+	
+	List<Instituto> institutos = new List<Instituto>((Instituto[])Enum.GetValues(typeof(Instituto))).Where(i => i != Instituto.Super).ToList();
 }
 
 <partial name="Header" view-data="@ViewData" />
@@ -144,10 +175,10 @@
 <script>
 	var prospeccoesDetalhes = [];
 
-	function trocarModalNovaProsp(){
+	function trocarModalNovaProsp() {
 		document.getElementById("botaoToggleProspFollowUp").disabled = true
 		valorSelect = document.getElementById("selectCreateProsp").value
-		if(valorSelect != "-1"){
+		if (valorSelect != "-1") {
 			document.getElementById("botaoToggleProspFollowUp").dataset.bsTarget = `#CreateFollowupProspModal-${valorSelect}-Toggle`
 			fetch(`/FunildeVendas/RetornarModal?idProsp=${valorSelect}&tipo=CreateFollowup`).then(response => response.text())
 				.then(result => {
@@ -247,7 +278,6 @@
 <div class="app-wrapper">
 	<div class="app-content pt-3 p-md-3 p-lg-4">
 		<div class="container-xl">
-
 			<div class="row g-3 mb-4 align-items-center justify-content-between">
 				<div class="col-auto">
 					<h1 class="app-page-title mb-0">Prospecções</h1>
@@ -267,7 +297,6 @@
 										<button type="submit" class="btn app-btn-primary">Lista Completa</button>
 									</div>
 								</form>
-
 							</div>
 							<div class="col-auto">
 								<select class="form-select w-auto" id="ano" name="ano" onchange="updateLink()">
@@ -294,7 +323,6 @@
 								@await Component.InvokeAsync("ModalCreateProsp")
 								<div id="modalCreateFollowUpProspContainer"></div> <!-- CONTAINER PARA ARMAZENAR O MODAL CREATE FOLLOWUP TEMPORARIAMENTE -->
 							</div>
-
 							<div class="col-auto" id="container-ajuda">
 								<a type="button" class="btn button-flash text-white" data-bs-toggle="modal" href="#modalTutorialFdv" role="button">
 									<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-octagon-fill" viewBox="0 0 16 16">
@@ -302,173 +330,120 @@
 									</svg> Tutorial!
 								</a>
 							</div>
-
 						</div>
 					</div>
 				</div>
 			</div>
 
-
 			<nav id="orders-table-tab" class="orders-table-tab app-nav-tabs nav shadow-sm flex-column flex-sm-row mb-4">
-				<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-dashboard-tab" data-bs-toggle="tab" href="#prospeccao-dashboard" role="tab" aria-controls="prospeccao-dashboard" aria-selected="true">Dashboard</a>
-				<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" data-bs-toggle="tab" href="#prospeccao-ativas" role="tab" aria-controls="prospeccao-ativas" aria-selected="false">Ativas (@ativas.Count())</a>
-				<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" data-bs-toggle="tab" href="#prospeccao-comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta (@propostas.Count())</a>
-				<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" data-bs-toggle="tab" href="#prospeccao-concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas (@concluidas.Count())</a>
-				<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" data-bs-toggle="tab" href="#prospeccao-planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas (@planejadas.Count())</a>
-				<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" data-bs-toggle="tab" href="#prospeccao-erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas (@erradas.Count())</a>
+				@if (string.IsNullOrEmpty(aba))
+				{
+					<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-dashboard-tab" data-bs-toggle="tab" href="#prospeccao-dashboard" role="tab" aria-controls="prospeccao-dashboard" aria-selected="true">Dashboard</a>
+				}
+				else
+				{
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-dashboard-tab" aria-controls="prospeccao-dashboard" aria-selected="false">Dashboard</a>
+				}
+				@if (!string.IsNullOrEmpty(aba))
+				{
+					if (aba.ToLowerInvariant() == "ativas")
+					{
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="true">Ativas (@ativas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+					} 
+					else if (aba.ToLowerInvariant() == "comproposta")
+					{
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="true">Com Proposta (@comproposta.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+					}
+					else if (aba.ToLowerInvariant() == "concluidas")
+					{
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="true">Concluídas (@concluidas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+					}
+					else if (aba.ToLowerInvariant() == "planejadas")
+					{
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="true">Planejadas (@planejadas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+					}
+					else if (aba.ToLowerInvariant() == "erradas")
+					{
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="true">Erradas (@erradas.Count())</a>
+					}
+					else
+					{
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+					}
+				} 
+				else
+				{
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+				}
+
 			</nav>
 
-
 			<div class="tab-content" id="orders-table-tab-content">
-				<div class="tab-pane fade show active" id="prospeccao-dashboard" role="tabpanel" aria-labelledby="prospeccao-dashboard-tab">
-					<div class="app-card app-card-orders-table mb-5">
-						<div class="app-card-body">
-							<partial name="graph_funil" view-data="@ViewData" />							
-						</div>
-					</div>
-
-				</div>
-
-				@*// TODO: Loop*@
-
-				<div class="tab-pane fade" id="prospeccao-ativas" role="tabpanel" aria-labelledby="prospeccao-ativas-tab">
-					<div class="app-card app-card-orders-table shadow-sm mb-5">
-						<div class="app-card-body">
-							<div class="table-responsive">
-
-								<table class="table mb-0 text-left">
-									<thead>
-										<tr>
-											<th class="cell">Logo</th>
-											<th class="cell">Empresa</th>
-											<th class="cell">Origem</th>
-											<th class="cell">Líder</th>
-											<th class="cell">Projeto</th>
-											<th class="cell">Tipo Contratação</th>
-											<th class="cell">Status</th>
-											<th class="cell">Temperatura</th>
-											<th class="cell">Valor</th>
-											<th class="cell">Detalhes</th>
-										</tr>
-									</thead>
-									<tbody>
-										@await Html.PartialAsync("ListaProsp", @ativas)
-									</tbody>
-								</table>
+				@if (string.IsNullOrEmpty(aba))
+				{
+					<div class="tab-pane fade show active" id="prospeccao-dashboard" role="tabpanel" aria-labelledby="prospeccao-dashboard-tab">
+						<div class="app-card app-card-orders-table mb-5">
+							<div class="app-card-body">
+								<partial name="graph_funil" view-data="@ViewData" />
 							</div>
 						</div>
 					</div>
-				</div>
-
-				<div class="tab-pane fade" id="prospeccao-comproposta" role="tabpanel" aria-labelledby="prospeccao-comproposta-tab">
-					<div class="app-card app-card-orders-table shadow-sm mb-5">
-						<div class="app-card-body">
-							<div class="table-responsive">
-								<table class="table mb-0 text-left">
-									<thead>
-										<tr>
-											<th class="cell">Logo</th>
-											<th class="cell">Empresa</th>
-											<th class="cell">Origem</th>
-											<th class="cell">Líder</th>
-											<th class="cell">Projeto</th>
-											<th class="cell">Tipo Contratação</th>
-											<th class="cell">Status</th>
-											<th class="cell">Temperatura</th>
-											<th class="cell">Valor</th>
-											<th class="cell">Detalhes</th>
-										</tr>
-									</thead>
-									<tbody>
-										@await Html.PartialAsync("ListaProsp", @propostas)									
-									</tbody>
-								</table>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				<div class="tab-pane fade" id="prospeccao-concluidas" role="tabpanel" aria-labelledby="prospeccao-concluidas-tab">
-					<div class="app-card app-card-orders-table shadow-sm mb-5">
-						<div class="app-card-body">
-							<div class="table-responsive">
-								<table class="table mb-0 text-left">
-									<thead>
-										<tr>
-											<th class="cell">Logo</th>
-											<th class="cell">Empresa</th>
-											<th class="cell">Origem</th>
-											<th class="cell">Líder</th>
-											<th class="cell">Projeto</th>
-											<th class="cell">Tipo Contratação</th>
-											<th class="cell">Status</th>
-											<th class="cell">Temperatura</th>
-											<th class="cell">Valor</th>
-											<th class="cell">Detalhes</th>
-										</tr>
-									</thead>
-									<tbody>
-										@await Html.PartialAsync("ListaProsp", @concluidas)
-									</tbody>
-								</table>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				<div class="tab-pane fade" id="prospeccao-planejadas" role="tabpanel" aria-labelledby="prospeccao-planejadas-tab">
-					<div class="app-card app-card-orders-table shadow-sm mb-5">
-						<div class="app-card-body">
-							<div class="table-responsive">
-								<table class="table mb-0 text-left">
-									<thead>
-										<tr>
-											<th class="cell">Logo</th>
-											<th class="cell">Empresa</th>
-											<th class="cell">Origem</th>
-											<th class="cell">Líder</th>
-											<th class="cell">Projeto</th>
-											<th class="cell">Tipo Contratação</th>
-											<th class="cell">Status</th>
-											<th class="cell">Valor</th>
-											<th class="cell">Detalhes</th>
-										</tr>
-									</thead>
-									<tbody>
-										@await Html.PartialAsync("ListaProsp", @planejadas)
-									</tbody>
-								</table>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				<div class="tab-pane fade" id="prospeccao-erradas" role="tabpanel" aria-labelledby="prospeccao-erradas-tab">
-					<div class="app-card app-card-orders-table shadow-sm mb-5">
-						<div class="app-card-body">
-							<div class="table-responsive">
-								<table class="table mb-0 text-left">
-									<thead>
-										<tr>
-											<th class="cell">Logo</th>
-											<th class="cell">Empresa</th>
-											<th class="cell">Líder</th>
-											<th class="cell">Projeto</th>
-											<th class="cell">Tipo Contratação</th>
-											<th class="cell">Status</th>
-											<th class="cell">Temperatura</th>
-											<th class="cell">Valor</th>
-											<th class="cell">Detalhes</th>
-										</tr>
-									</thead>
-									<tbody>
-										@await Html.PartialAsync("ListaProsp", @erradas)
-									</tbody>
-								</table>
-							</div>
-						</div>
-					</div>
-				</div>
+				}
+				else
+				{
+					if (aba.ToLowerInvariant() == "ativas")
+					{
+						@await Html.PartialAsync("ListaProsp", ativas)
+					}
+					else if (aba.ToLowerInvariant() == "comproposta")
+					{
+						@await Html.PartialAsync("ListaProsp", comproposta)
+					}
+					else if (aba.ToLowerInvariant() == "concluidas")
+					{
+						@await Html.PartialAsync("ListaProsp", concluidas)
+					}
+					else if (aba.ToLowerInvariant() == "planejadas")
+					{
+						@await Html.PartialAsync("ListaProsp", planejadas)
+					}
+					else if (aba.ToLowerInvariant() == "erradas")
+					{
+						@await Html.PartialAsync("ListaProsp", erradas)
+					}
+					else
+					{
+						
+					}
+				}
 			</div>
 		</div>
 	</div>

--- a/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
@@ -364,7 +364,7 @@
 					}
 					else if (aba.ToLowerInvariant() == "concluidas")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
 						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="true">Concluídas (@concluidas.Count())</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>

--- a/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
@@ -348,60 +348,60 @@
 				{
 					if (aba.ToLowerInvariant() == "ativas")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="true">Ativas (@ativas.Count())</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="true">Ativas (@ativas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					} 
 					else if (aba.ToLowerInvariant() == "comproposta")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="true">Com Proposta (@comproposta.Count())</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="true">Com Proposta (@comproposta.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					}
 					else if (aba.ToLowerInvariant() == "concluidas")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="true">Concluídas (@concluidas.Count())</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="true">Concluídas (@concluidas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					}
 					else if (aba.ToLowerInvariant() == "planejadas")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="true">Planejadas (@planejadas.Count())</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="true">Planejadas (@planejadas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					}
 					else if (aba.ToLowerInvariant() == "erradas")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="true">Erradas (@erradas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="true">Erradas (@erradas.Count())</a>
 					}
 					else
 					{
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="@aba" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
+						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					}
 				} 
 				else
 				{
-					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" href="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" href="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" href="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" href="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" href="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" aria-selected="false">Planejadas</a>
+					<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 				}
 
 			</nav>

--- a/BaseDeProjetos/Views/FunilDeVendas/ListaProsp.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/ListaProsp.cshtml
@@ -3,7 +3,9 @@
 @using BaseDeProjetos.Helpers
 @{
     var ptbr = new CultureInfo("pt-BR");
-
+    var dadosDaRota = ViewContext.RouteData;
+    string aba = dadosDaRota.Values["aba"] as string;
+    aba = aba.ToLowerInvariant();
 }
 <style>
     * {
@@ -12,98 +14,123 @@
         padding: 0;
     }
 </style>
-@* <script>
-    var bt = document.querySelector('#bt')
 
-    bt.addEventListener('click', e => {
-    e.preventDefault();
-    })
-
-    $(function () {
-    $('[data-bs-toggle="popover"]').popover()
-    })
-    </script> *@
-@foreach (var prospeccao in Model)
-{
-    <tr id="table-row-@prospeccao.Id">
-        @if (prospeccao.Empresa.Logo != null)
-        {
-            <td class="cell"><img loading="lazy" src="@prospeccao.Empresa.Logo" id="logoEmpresa" alt="Logo da Empresa"
-            style="background-color:white"></td>
-        }
-        else
-        {
-            <td class="cell">
-                <nobr id="logo_alt">Sem Logo</nobr>
-            </td>
-        }
-        <td class="cell">@prospeccao.Empresa.Nome</td> @*Empresa*@
-        <td class="cell">
-            <div style="width: 40px; height: 40px;" class="position-relative">
-                @if(prospeccao.Status.OrderBy(p => p.Data).First().Status == StatusProspeccao.Planejada){
-                <span class="position-absolute top-10 start-100 translate-middle badge rounded-pill bg-info">Plan</span>
-                }
-                @if(prospeccao.Origem.GetDisplayName() == "Recebida"){
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.3.0 by fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M64 112c-8.8 0-16 7.2-16 16v22.1L220.5 291.7c20.7 17 50.4 17 71.1 0L464 150.1V128c0-8.8-7.2-16-16-16H64zM48 212.2V384c0 8.8 7.2 16 16 16H448c8.8 0 16-7.2 16-16V212.2L322 328.8c-38.4 31.5-93.7 31.5-132 0L48 212.2zM0 128C0 92.7 28.7 64 64 64H448c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128z"/></svg>
-                } else {
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.3.0 by fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M16.1 260.2c-22.6 12.9-20.5 47.3 3.6 57.3L160 376V479.3c0 18.1 14.6 32.7 32.7 32.7c9.7 0 18.9-4.3 25.1-11.8l62-74.3 123.9 51.6c18.9 7.9 40.8-4.5 43.9-24.7l64-416c1.9-12.1-3.4-24.3-13.5-31.2s-23.3-7.5-34-1.4l-448 256zm52.1 25.5L409.7 90.6 190.1 336l1.2 1L68.2 285.7zM403.3 425.4L236.7 355.9 450.8 116.6 403.3 425.4z"/></svg>
-                }
+<div class="tab-pane fade show active" id="prospeccao-@aba" role="tabpanel" aria-labelledby="prospeccao-@aba-tab">
+    <div class="app-card app-card-orders-table shadow-sm mb-5">
+        <div class="app-card-body">
+            <div class="table-responsive">
+                <table class="table mb-0 text-left">
+                    <thead>
+                        <tr>
+                            <th class="cell">Logo</th>
+                            <th class="cell">Empresa</th>
+                            <th class="cell">Origem</th>
+                            <th class="cell">Líder</th>
+                            <th class="cell">Projeto</th>
+                            <th class="cell">Tipo Contratação</th>
+                            <th class="cell">Status</th>
+                            <th class="cell">Temperatura</th>
+                            <th class="cell">Valor</th>
+                            <th class="cell">Detalhes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var prospeccao in Model)
+                        {
+                            <tr id="table-row-@prospeccao.Id">
+                                @if (prospeccao.Empresa.Logo != null)
+                                {
+                                    <td class="cell">
+                                        <img loading="lazy" src="@prospeccao.Empresa.Logo" id="logoEmpresa" alt="Logo da Empresa"
+                                             style="background-color:white">
+                                    </td>
+                                }
+                                else
+                                {
+                                    <td class="cell">
+                                        <nobr id="logo_alt">Sem Logo</nobr>
+                                    </td>
+                                }
+                                <td class="cell">@prospeccao.Empresa.Nome</td> @*Empresa*@
+                                <td class="cell">
+                                    <div style="width: 40px; height: 40px;" class="position-relative">
+                                        @if (prospeccao.Status.OrderBy(p => p.Data).First().Status == StatusProspeccao.Planejada)
+                                        {
+                                            <span class="position-absolute top-10 start-100 translate-middle badge rounded-pill bg-info">Plan</span>
+                                        }
+                                        @if (prospeccao.Origem.GetDisplayName() == "Recebida")
+                                        {
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.3.0 by fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M64 112c-8.8 0-16 7.2-16 16v22.1L220.5 291.7c20.7 17 50.4 17 71.1 0L464 150.1V128c0-8.8-7.2-16-16-16H64zM48 212.2V384c0 8.8 7.2 16 16 16H448c8.8 0 16-7.2 16-16V212.2L322 328.8c-38.4 31.5-93.7 31.5-132 0L48 212.2zM0 128C0 92.7 28.7 64 64 64H448c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128z" /></svg>
+                                        }
+                                        else
+                                        {
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.3.0 by fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M16.1 260.2c-22.6 12.9-20.5 47.3 3.6 57.3L160 376V479.3c0 18.1 14.6 32.7 32.7 32.7c9.7 0 18.9-4.3 25.1-11.8l62-74.3 123.9 51.6c18.9 7.9 40.8-4.5 43.9-24.7l64-416c1.9-12.1-3.4-24.3-13.5-31.2s-23.3-7.5-34-1.4l-448 256zm52.1 25.5L409.7 90.6 190.1 336l1.2 1L68.2 285.7zM403.3 425.4L236.7 355.9 450.8 116.6 403.3 425.4z" /></svg>
+                                        }
+                                    </div>
+                                </td>
+                                <td class="cell">
+                                    @if (prospeccao.Usuario != null)
+                                    {
+                                        <span class="badge bg-success">@prospeccao.Usuario.UserName</span> @*Líder*@
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-danger">Sem Líder</span>
+                                    }
+                                </td>
+                                <td class="cell">
+                                    @if (prospeccao.NomeProspeccao != null)
+                                    {
+                                        <span>@prospeccao.NomeProspeccao</span> @*Projeto*@
+                                    }
+                                    else
+                                    {
+                                        <span>A definir</span> @*Projeto*@
+                                    }
+                                </td>
+                                @{
+                                    var subtracaoUltimoStatus = @DateTime.Now.Subtract(prospeccao.Status.OrderBy(followup => followup.Data).Last().Data).Days;
+                                }
+                                <td class="cell">
+                                    <span>@prospeccao.TipoContratacao.GetDisplayName()</span> @*Tipo Contratação*@
+                                </td>
+                                <td class="cell">
+                                    <span>@prospeccao.Status.OrderBy(followup => followup.Data).Last().Status.GetDisplayName()</span>
+                                </td> @*Status*@
+                                @if (prospeccao.Status.OrderBy(followup => followup.Data).Last().Status != StatusProspeccao.Planejada)
+                                {
+                                    <td class="cell">
+                                        @if (prospeccao.Status.OrderBy(followup => followup.Data).Last().Status != StatusProspeccao.Planejada)
+                                        {
+                                            @FunilHelpers.VerificarTemperatura(subtracaoUltimoStatus)
+                                        }
+                                    </td>
+                                }
+                                <td class="cell">
+                                    @if (prospeccao.ValorProposta != 0)
+                                    {
+                                        <span>R$ @Helpers.FormatarValoresDashboards((decimal)prospeccao.ValorProposta)</span>
+                                    }
+                                    else if (prospeccao.ValorEstimado != 0)
+                                    {
+                                        <span>R$ @Helpers.FormatarValoresDashboards((decimal)prospeccao.ValorEstimado)</span>
+                                    }
+                                    else
+                                    {
+                                        <span>Valor não informado</span>
+                                    }
+                                </td>
+                                <td class="cell">
+                                    <button type="button" id="button-@prospeccao.Id" onmouseover="carregarModaisFunil('@prospeccao.Id')" data-bs-target="#modalDetalhes-@prospeccao.Id"
+                                            data-bs-toggle="modal" class="btn-sm app-btn-primary">
+                                        Detalhes
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
             </div>
-        </td>
-        <td class="cell">
-            @if (prospeccao.Usuario != null)
-            {
-                <span class="badge bg-success">@prospeccao.Usuario.UserName</span> @*Líder*@
-            }
-            else
-            {
-                <span class="badge bg-danger">Sem Líder</span>
-            }
-        </td>
-        <td class="cell">
-            @if (prospeccao.NomeProspeccao != null)
-            {
-                <span>@prospeccao.NomeProspeccao</span> @*Projeto*@
-            }
-            else
-            {
-                <span>A definir</span> @*Projeto*@
-            }
-        </td>
-        @{
-            var subtracaoUltimoStatus = @DateTime.Now.Subtract(prospeccao.Status.OrderBy(followup => followup.Data).Last().Data).Days;
-        }
-        <td class="cell">
-            <span>@prospeccao.TipoContratacao.GetDisplayName()</span> @*Tipo Contratação*@
-        </td>
-        <td class="cell"><span>@prospeccao.Status.OrderBy(followup => followup.Data).Last().Status.GetDisplayName()</span>
-        </td> @*Status*@
-        @if (prospeccao.Status.OrderBy(followup => followup.Data).Last().Status != StatusProspeccao.Planejada)
-        {
-            <td class="cell">
-                @if (prospeccao.Status.OrderBy(followup => followup.Data).Last().Status != StatusProspeccao.Planejada)
-                {
-                    @FunilHelpers.VerificarTemperatura(subtracaoUltimoStatus)
-                }
-            </td>
-        }
-        <td class="cell">
-            @if (prospeccao.ValorProposta != 0)
-            {
-                <span>R$ @Helpers.FormatarValoresDashboards((decimal)prospeccao.ValorProposta)</span>
-            }
-            else if (prospeccao.ValorEstimado != 0)
-            {
-                <span>R$ @Helpers.FormatarValoresDashboards((decimal)prospeccao.ValorEstimado)</span>
-            }
-            else
-            {
-                <span>Valor não informado</span>
-            }
-        </td>
-        <td class="cell">
-            <button type="button" id="button-@prospeccao.Id" onmouseover="carregarModaisFunil('@prospeccao.Id')" data-bs-target="#modalDetalhes-@prospeccao.Id"
-            data-bs-toggle="modal" class="btn-sm app-btn-primary">Detalhes</button>
-        </td>
-    </tr>
-}
+        </div>
+    </div>
+</div>

--- a/BaseDeProjetos/Views/FunilDeVendas/ListaProsp.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/ListaProsp.cshtml
@@ -29,7 +29,10 @@
                             <th class="cell">Projeto</th>
                             <th class="cell">Tipo Contratação</th>
                             <th class="cell">Status</th>
-                            <th class="cell">Temperatura</th>
+                            @if (@aba != "planejadas") 
+                            {
+                                <th class="cell">Temperatura</th>
+                            }                            
                             <th class="cell">Valor</th>
                             <th class="cell">Detalhes</th>
                         </tr>
@@ -97,13 +100,10 @@
                                 <td class="cell">
                                     <span>@prospeccao.Status.OrderBy(followup => followup.Data).Last().Status.GetDisplayName()</span>
                                 </td> @*Status*@
-                                @if (prospeccao.Status.OrderBy(followup => followup.Data).Last().Status != StatusProspeccao.Planejada)
+                                @if (prospeccao.Status.Any(f => f.Status == StatusProspeccao.Planejada))
                                 {
-                                    <td class="cell">
-                                        @if (prospeccao.Status.OrderBy(followup => followup.Data).Last().Status != StatusProspeccao.Planejada)
-                                        {
-                                            @FunilHelpers.VerificarTemperatura(subtracaoUltimoStatus)
-                                        }
+                                    <td class="cell">                
+                                        @FunilHelpers.VerificarTemperatura(subtracaoUltimoStatus)
                                     </td>
                                 }
                                 <td class="cell">

--- a/BaseDeProjetos/Views/FunilDeVendas/graph_funil.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/graph_funil.cshtml
@@ -11,6 +11,8 @@
     }
 </style>
 @{
+    // TODO: Alguém me otimize/me refatore por favor 😶
+
     IEnumerable<BaseDeProjetos.Models.Prospeccao> Prospeccoes = ViewData["ListaProspeccoes"] as
             IEnumerable<BaseDeProjetos.Models.Prospeccao>;
     Dictionary<string, int> contagem = new Dictionary<string, int>();
@@ -24,8 +26,6 @@
             FunilHelpers.VerificarStatus(p, status)).ToList().Count();
         }
     }
-
-    //ATIVAS \/ \/ \/ \/ \/ \/
 
     var prospec_ativas = Prospeccoes.Where(p => p.Status.OrderBy(k => k.Data).All(pa => pa.Status ==
     StatusProspeccao.ContatoInicial || pa.Status == StatusProspeccao.Discussao_EsbocoProjeto || pa.Status ==
@@ -55,7 +55,7 @@
     decimal n_empresas = prospec_totais.Select(p => p.Empresa.EmpresaUnique).Distinct().Count();
     decimal n_planejadas = Prospeccoes.Where(p => p.Status.Any(s => s.Status == StatusProspeccao.Planejada)).Count();
 
-    //Novo Filtro:
+    // Novo Filtro:
     decimal n_empresas_ativas = prospec_ativas.Select(p => p.Empresa.EmpresaUnique).Distinct().Count();
     var avancadas = Prospeccoes.Where(p => p.Status.Any(k => k.Status == StatusProspeccao.ComProposta)).
     Where(p => p.Status.Any(k => k.Status > StatusProspeccao.ComProposta)). // lista de prospecção (selecionar com proposta)
@@ -147,8 +147,6 @@
                 <label class="form-check-label" for="botao_ativas">Mostrar apenas as ativas</label>
             </div>
         </div>
-
-
     </div>
 
     <div class="pb-4">

--- a/BaseDeProjetos/Views/Shared/Sidebar.cshtml
+++ b/BaseDeProjetos/Views/Shared/Sidebar.cshtml
@@ -165,7 +165,7 @@
 										string casa_nome = Enum.GetName(typeof(Instituto), casa);
 										string id_casa = "collapse_" + casa_nome;
 
-										<li class="submenu-item"><a class="submenu-link" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa_nome">@casa_nome</a></li>
+										<li class="submenu-item"><a class="submenu-link" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa_nome" asp-route-aba="">@casa_nome</a></li>
 									}
 								</ul>
 							</div>


### PR DESCRIPTION
Agora apenas puxamos as prospecções de acordo com status caso o usuário clique na aba referente ao mesmo.

Por exemplo, o usuário clicou em "Ativas", ele será redirecionado para um pseudo-rota "Ativas" que irá automaticamente puxar apenas as prospecções ativas e nada mais, diminuindo a carga no servidor, a carga de rede e consequentemente o tempo de resposta para abrir o funil de vendas.

Otimizações futuras: Seria útil que futuramente se otimizasse o partial dos gráficos do funil visto que existem diversas funções e lógica que poderia estar escondida no controller do Index.