### PR TITLE
Paginar o funil de vendas

### DIFF
--- a/BaseDeProjetos/Helpers/FunilHelpers.cs
+++ b/BaseDeProjetos/Helpers/FunilHelpers.cs
@@ -111,25 +111,25 @@ namespace BaseDeProjetos.Helpers
             }
         }
 
-        public static void CategorizarProspecçõesNaView(List<Prospeccao> lista, Usuario usuario, string aba, HttpContext HttpContext, dynamic ViewBag)
+        public static List<Prospeccao> RetornarProspeccoesPorStatus(List<Prospeccao> lista, Usuario usuario, string aba, HttpContext HttpContext)
         {
 
             if (aba.ToLowerInvariant() == "ativas") 
             {
                 List<Prospeccao> ativas = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status < StatusProspeccao.ComProposta).ToList();
-                ViewBag.Ativas = ativas;
+                return ativas;
             }
             else if (aba.ToLowerInvariant() == "comproposta")
             {
                 List<Prospeccao> emProposta = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).LastOrDefault().Status == StatusProspeccao.ComProposta).ToList();
-                ViewBag.EmProposta = emProposta;
+                return emProposta;
             } 
             else if (aba.ToLowerInvariant() == "concluidas")
             {
                 List<Prospeccao> concluidas = lista.Where(prospeccao => prospeccao.Status.Any(followup => followup.Status == StatusProspeccao.Convertida ||
                                                               followup.Status == StatusProspeccao.Suspensa ||
                                                               followup.Status == StatusProspeccao.NaoConvertida)).ToList();
-                ViewBag.Concluidas = concluidas;
+                return concluidas;
             } 
             else if (aba.ToLowerInvariant() == "planejadas")
             {
@@ -137,17 +137,17 @@ namespace BaseDeProjetos.Helpers
                 List<Prospeccao> planejadas = usuario.Nivel == Nivel.Dev ?
                             lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).ToList() :
                             lista.Where(prospeccao => prospeccao.Status.All(followup => followup.Status == StatusProspeccao.Planejada)).Where(prosp => prosp.Usuario.UserName.ToString() == HttpContext.User.Identity.Name).ToList();
-                ViewBag.Planejadas = planejadas;
+                return planejadas;
             } 
             else if (aba.ToLowerInvariant() == "erradas")
             {
                 List<Prospeccao> erradas = lista.Where(prospeccao => prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.ContatoInicial
                             && prospeccao.Status.OrderBy(followup => followup.Data).FirstOrDefault().Status != StatusProspeccao.Planejada).ToList();
-                ViewBag.Erradas = erradas;
+                return erradas;
             } 
             else
             {
-                return;
+                return null;
             }            
         }
 

--- a/BaseDeProjetos/Helpers/Pager.cs
+++ b/BaseDeProjetos/Helpers/Pager.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BaseDeProjetos.Helpers
+{
+    public class Pager
+    {
+        public int ItensTotais { get; private set; }
+        public int PaginaAtual { get; private set; }
+        public int TamanhoDaPagina { get; private set; }
+        public int TotalPaginas { get; private set; }
+
+        public List<int> Pages { get; set; }
+
+        public Pager(int itensTotais, int paginaAtual, int tamanhoDaPagina, int maximoDePaginas)
+        {
+            ItensTotais = itensTotais;
+            PaginaAtual = paginaAtual;
+            TamanhoDaPagina = tamanhoDaPagina;
+
+            // Numero de paginas
+            TotalPaginas = (int)Math.Ceiling((double)ItensTotais / TamanhoDaPagina);
+
+            PaginaAtual = Math.Max(1, Math.Min(PaginaAtual, TotalPaginas));
+
+            int paginaInicial = 1;
+            int paginaFinal = TotalPaginas;
+
+            if (TotalPaginas > maximoDePaginas)
+            {
+                int maxPagesBeforeCurrentPage = (int)Math.Floor((double)maximoDePaginas / 2);
+                int maxPagesAfterCurrentPage = (int)Math.Ceiling((double)maximoDePaginas / 2) - 1;
+                if (PaginaAtual <= maxPagesBeforeCurrentPage)
+                {
+                    paginaFinal = maximoDePaginas;
+                }
+                else if (PaginaAtual >= TotalPaginas - maxPagesAfterCurrentPage)
+                {
+                    paginaInicial = TotalPaginas - maximoDePaginas + 1;
+                }
+                else
+                {
+                    paginaInicial = PaginaAtual - maxPagesBeforeCurrentPage;
+                    paginaFinal = PaginaAtual + maxPagesAfterCurrentPage;
+                }
+            }
+
+            Pages = Enumerable.Range(paginaInicial, paginaFinal - paginaInicial + 1).ToList();
+        }
+
+        public bool TemPaginaAnterior => PaginaAtual > 1;
+        public bool TemProximaPagina => PaginaAtual < TotalPaginas;
+    }
+}

--- a/BaseDeProjetos/Models/ProspeccoesViewModel.cs
+++ b/BaseDeProjetos/Models/ProspeccoesViewModel.cs
@@ -1,0 +1,12 @@
+﻿using BaseDeProjetos.Helpers;
+using System.Collections.Generic;
+
+namespace BaseDeProjetos.Models
+{
+    public class ProspeccoesViewModel
+    {
+        public List<Prospeccao> Prospeccoes { get; set; }
+        public Pager Pager { get; set; }
+
+    }
+}

--- a/BaseDeProjetos/ViewComponents/Sidebar/SidebarViewComponent.cs
+++ b/BaseDeProjetos/ViewComponents/Sidebar/SidebarViewComponent.cs
@@ -24,6 +24,7 @@ namespace BaseDeProjetos.ViewComponents.Sidebar
                 ViewBag.usuarioCasa = usuario.Casa;
                 ViewBag.usuarioNivel = usuario.Nivel;
                 ViewData["UsuarioNivel"] = usuario.Nivel;
+                ViewData["UsuarioCasa"] = usuario.Casa;
             }           
 
             return View();

--- a/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model IEnumerable<BaseDeProjetos.Models.Prospeccao>
+﻿@model ProspeccoesViewModel
+@using BaseDeProjetos.Helpers;
 @using Microsoft.AspNetCore.Http;
 @{
 	ViewData["Title"] = "Funil de Vendas";
@@ -6,37 +7,6 @@
 	var dadosDaRota = ViewContext.RouteData;
 	string aba = dadosDaRota.Values["aba"] as string;
 	string casa = dadosDaRota.Values["casa"] as string;
-	//aba = aba.ToLowerInvariant(); // Safeguard
-
-	List<Prospeccao> ativas = new List<Prospeccao>();
-	List<Prospeccao> comproposta = new List<Prospeccao>();
-	List<Prospeccao> concluidas = new List<Prospeccao>();
-	List<Prospeccao> erradas = new List<Prospeccao>();
-	List<Prospeccao> planejadas = new List<Prospeccao>();
-
-	if (!string.IsNullOrEmpty(aba))
-	{
-		if (aba.ToLowerInvariant() == "ativas")
-		{
-			ativas = ViewBag.Ativas as List<Prospeccao>;
-		}
-		else if (aba.ToLowerInvariant() == "comproposta")
-		{
-			comproposta = ViewBag.EmProposta as List<Prospeccao>;
-		}
-		else if (aba.ToLowerInvariant() == "concluidas")
-		{
-			concluidas = ViewBag.Concluidas as List<Prospeccao>;
-		} 
-		else if (aba.ToLowerInvariant() == "erradas")
-		{
-			erradas = ViewBag.Erradas as List<Prospeccao>;
-		}
-		else if (aba.ToLowerInvariant() == "planejadas")
-		{
-			planejadas = ViewBag.Planejadas as List<Prospeccao>;
-		}
-	}	
 
 	if (string.IsNullOrEmpty(casa))
 	{
@@ -353,7 +323,7 @@
 				{
 					if (aba.ToLowerInvariant() == "ativas")
 					{
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="true">Ativas (@ativas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="true">Ativas (@Model.Prospeccoes.Count())</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
@@ -362,7 +332,7 @@
 					else if (aba.ToLowerInvariant() == "comproposta")
 					{
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="true">Com Proposta (@comproposta.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="true">Com Proposta (@Model.Prospeccoes.Count())</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
@@ -371,7 +341,7 @@
 					{
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="true">Concluídas (@concluidas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="true">Concluídas (@Model.Prospeccoes.Count())</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					}
@@ -380,7 +350,7 @@
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-ativas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="ativas" aria-controls="prospeccao-ativas" aria-selected="false">Ativas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="true">Planejadas (@planejadas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="true">Planejadas (@Model.Prospeccoes.Count())</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="false">Erradas</a>
 					}
 					else if (aba.ToLowerInvariant() == "erradas")
@@ -389,7 +359,7 @@
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-comproposta-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="comproposta" role="tab" aria-controls="prospeccao-comproposta" aria-selected="false">Com Proposta</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-concluidas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="concluidas" role="tab" aria-controls="prospeccao-concluidas" aria-selected="false">Concluídas</a>
 						<a class="flex-sm-fill text-sm-center nav-link" id="prospeccao-planejadas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="planejadas" role="tab" aria-controls="prospeccao-planejadas" aria-selected="false">Planejadas</a>
-						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="true">Erradas (@erradas.Count())</a>
+						<a class="flex-sm-fill text-sm-center nav-link active" id="prospeccao-erradas-tab" asp-action="Index" asp-controller="FunilDeVendas" asp-route-casa="@casa" asp-route-aba="erradas" role="tab" aria-controls="prospeccao-erradas" aria-selected="true">Erradas (@Model.Prospeccoes.Count())</a>
 					}
 					else
 					{
@@ -424,32 +394,63 @@
 				}
 				else
 				{
-					if (aba.ToLowerInvariant() == "ativas")
-					{
-						@await Html.PartialAsync("ListaProsp", ativas)
-					}
-					else if (aba.ToLowerInvariant() == "comproposta")
-					{
-						@await Html.PartialAsync("ListaProsp", comproposta)
-					}
-					else if (aba.ToLowerInvariant() == "concluidas")
-					{
-						@await Html.PartialAsync("ListaProsp", concluidas)
-					}
-					else if (aba.ToLowerInvariant() == "planejadas")
-					{
-						@await Html.PartialAsync("ListaProsp", planejadas)
-					}
-					else if (aba.ToLowerInvariant() == "erradas")
-					{
-						@await Html.PartialAsync("ListaProsp", erradas)
-					}
-					else
-					{
-						
-					}
+					@await Html.PartialAsync("ListaProsp", Model);
 				}
 			</div>
+
+			@if (!string.IsNullOrEmpty(aba))
+			{
+				<nav>
+					<ul class="pagination justify-content-center">
+
+						@if (Model.Pager.TotalPaginas > 1)
+						{
+							@if (Model.Pager.TemPaginaAnterior)
+							{
+								<li class="page-item">
+									<a class="page-link" asp-action="">Anterior</a>
+								</li>
+							}
+							else
+							{
+								<li class="page-item disabled">
+									<a class="page-link" asp-action="">Anterior</a>
+								</li>
+							}
+
+							@foreach (var numeroPagina in Model.Pager.Pages)
+							{
+								if (numeroPagina == Model.Pager.PaginaAtual)
+								{
+									<li class="page-item active">
+										<a class="page-link" asp-controller="FunilDeVendas" asp-action="Index" asp-route-casa="@casa" asp-route-aba="@aba" asp-route-numeroPagina="@(numeroPagina-1)">@numeroPagina</a>
+									</li>
+								}
+								else
+								{
+									<li class="page-item">
+										<a class="page-link" asp-controller="FunilDeVendas" asp-action="Index" asp-route-casa="@casa" asp-route-aba="@aba" asp-route-numeroPagina="@numeroPagina">@numeroPagina</a>
+									</li>
+								}
+							}
+
+							@if (Model.Pager.TemProximaPagina)
+							{
+								<li class="page-item">
+									<a class="page-link" asp-controller="FunilDeVendas" asp-action="Index" asp-route-casa="@casa" asp-route-aba="@aba" asp-route-numeroPagina="@(Model.Pager.PaginaAtual + 1)">Proximo</a>
+								</li>
+							}
+							else
+							{
+								<li class="page-item disabled">
+									<a class="page-link">Proximo</a>
+								</li>
+							}
+						}
+
+				</ul>
+			</nav>
+			}
 		</div>
 	</div>
 	<partial name="Footer" />

--- a/BaseDeProjetos/Views/FunilDeVendas/ListaProsp.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/ListaProsp.cshtml
@@ -1,10 +1,11 @@
-﻿@model IEnumerable<BaseDeProjetos.Models.Prospeccao>
+﻿@model ProspeccoesViewModel
 @using System.Globalization
 @using BaseDeProjetos.Helpers
 @{
     var ptbr = new CultureInfo("pt-BR");
     var dadosDaRota = ViewContext.RouteData;
     string aba = dadosDaRota.Values["aba"] as string;
+    string casa = dadosDaRota.Values["casa"] as string;
     aba = aba.ToLowerInvariant();
 }
 <style>
@@ -38,7 +39,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var prospeccao in Model)
+                        @foreach (var prospeccao in Model.Prospeccoes)
                         {
                             <tr id="table-row-@prospeccao.Id">
                                 <td class="cell">
@@ -134,7 +135,7 @@
                             </tr>
                         }
                     </tbody>
-                </table>
+                </table>               
             </div>
         </div>
     </div>

--- a/BaseDeProjetos/Views/FunilDeVendas/graph_funil.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/graph_funil.cshtml
@@ -1,4 +1,4 @@
-﻿@model IEnumerable<BaseDeProjetos.Models.Prospeccao>
+﻿@model ProspeccoesViewModel
 @using System
 @using BaseDeProjetos.Helpers
 <style>


### PR DESCRIPTION
O Funil de Vendas sempre foi um muro de conteudo, a paginacao não so trara uma maior performance como uma navegacao mais eficaz.

As mudanças realizadas foram:

1. Refactor no controller do funil de vendas, apenas retornando as prospecções da aba selecionada
2. Navegador de paginação com o uso do Bootstrap
3. Implementação de uma classe helper "Pager" para a paginação de qualquer model
4. A criação de um ViewModel para o Funil que segura uma lista de prospecções assim como uma instância da classe Pager
5. Remoção do Tutorial do Funil de Vendas para extrair performance extra. Visto que o mesmo esta ha meses no SGI sem efeito.
