### PR TITLE
Separar a logica dos graficos do dashboard do Funil de Vendas

### DIFF
--- a/BaseDeProjetos/Controllers/FunilDeVendasController.cs
+++ b/BaseDeProjetos/Controllers/FunilDeVendasController.cs
@@ -34,6 +34,17 @@ namespace BaseDeProjetos.Controllers
             _cache = cache;
         }
 
+        public async Task<IActionResult> GerarIndicadoresProsp()
+        {
+            int prospeccoes =  _context.Prospeccao.Select(p => new {p.Empresa}).Distinct().Count();
+
+            int prospeccoesContatoInicial = _context.Prospeccao.Select(p => new {p.Status}).Where(p => p.Status.Any(p => p.Status == StatusProspeccao.ContatoInicial)).Count();
+
+            int prospeccoesInfrutiferas = _context.Prospeccao.Select(p => new {p.Status}).Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.NaoConvertida).Count();
+            double percentInfrutiferas = (double) prospeccoesInfrutiferas / _context.Prospeccao.Select(p => new { p.Id }).Count() * 100;
+        }
+
+
         // GET: FunilDeVendas
         [Route("FunilDeVendas/Index/{casa?}/{aba?}/{ano?}")]
         public async Task<IActionResult> Index(string casa, string aba, string sortOrder = "", string searchString = "", string ano = "", int numeroPagina = 1, int tamanhoPagina = 20)
@@ -82,10 +93,10 @@ namespace BaseDeProjetos.Controllers
                 model.ProspeccoesAtivas = prospeccoes.Where(
                         p => p.Status.OrderBy(k => k.Data).All(
                             pa => pa.Status == StatusProspeccao.ContatoInicial || pa.Status == StatusProspeccao.Discussao_EsbocoProjeto || pa.Status == StatusProspeccao.ComProposta)).ToList();
-                model.ProspeccoesComProposta = prospeccoes.Where(p => p.Status.OrderBy(k => k.Data).Any(f => f.Status == StatusProspeccao.ComProposta)).ToList();
-                model.ProspeccoesConcluidas = prospeccoes.Where(p => p.Status.OrderBy(k => k.Data).Any(f => f.Status == StatusProspeccao.Convertida)).ToList();
-                model.ProspeccoesPlanejadas = prospeccoes.Where(p => p.Status.OrderBy(k => k.Data).Any(f => f.Status == StatusProspeccao.Planejada)).ToList();
-                model.ProspeccoesNaoPlanejadas = prospeccoes.Where(p => p.Status.OrderBy(k => k.Data).Any(f => f.Status != StatusProspeccao.Planejada)).ToList();
+                model.ProspeccoesComProposta = prospeccoes.Select(p => new { p.Status }).Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.ComProposta).ToList().Count();
+                model.ProspeccoesConcluidas = prospeccoes.Select(p => new { p.Status }).Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.Convertida).ToList().Count();
+                model.ProspeccoesPlanejadas = prospeccoes.Select(p => new { p.Status }).Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.Planejada).ToList().Count();
+                model.ProspeccoesNaoPlanejadas= prospeccoes.Where(p => p.Status.OrderBy(f => f.Data).Last().Status != StatusProspeccao.Planejada).ToList();
 
                 if (!string.IsNullOrEmpty(aba))
                 {

--- a/BaseDeProjetos/Controllers/FunilDeVendasController.cs
+++ b/BaseDeProjetos/Controllers/FunilDeVendasController.cs
@@ -49,7 +49,7 @@ namespace BaseDeProjetos.Controllers
             return GerarQuantidadeProsp(prospeccoes, p => p.Status.Any(p => p.Status == status) && p.TipoContratacao == tipo );
         }
 
-        [Route("{casa}")]
+        [Route("FunilDeVendas/GerarGraficoBarraTipoContratacao/{casa}")]
         public async Task<IActionResult> GerarGraficoBarraTipoContratacao(string casa)
         {
 
@@ -117,7 +117,7 @@ namespace BaseDeProjetos.Controllers
         }
 
 
-        [Route("{casa}")]
+        [Route("FunilDeVendas/GerarIndicadoresProsp/{casa}")]
         public async Task<IActionResult> GerarIndicadoresProsp(string casa)
         {
 
@@ -127,7 +127,17 @@ namespace BaseDeProjetos.Controllers
             {
                 throw new ArgumentException("A casa selecionada é inválida");
             }
-            
+
+
+            var x = _context.Prospeccao
+                .Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.NaoConvertida
+                || p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.Suspensa)
+                .Where(p => p.Casa == Instituto.ISIQV)
+                .Count();
+
+            double z = _context.Prospeccao.Where(p => p.Casa == Instituto.ISIQV).Count();
+
+            var resultado = x / z;
 
             //todas prospepccoes que possui status em proposta e status inicial, duracao de dias 
             List<TimeSpan> intervaloDatas = new List<TimeSpan>();
@@ -144,14 +154,18 @@ namespace BaseDeProjetos.Controllers
             var mediaintervalos = new TimeSpan(Convert.ToInt64(intervaloDatas.Average(t => t.Ticks)));
             double tempoMedioContato = mediaintervalos.TotalDays;
             int prospContatoInicial = _context.Prospeccao.Select(p => new { p.Status, p.Casa }).Where(p => p.Status.Any(p => p.Status == StatusProspeccao.ContatoInicial) && p.Casa == enumCasa).Count();
-            int prospeccoesInfrutiferas = _context.Prospeccao.Select(p => new { p.Status, p.Casa }).Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.NaoConvertida || p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.Suspensa && p.Casa == enumCasa).Count();
+            int prospeccoesInfrutiferas = _context.Prospeccao
+                .Select(p => new { p.Status, p.Casa })
+                .Where(p => p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.NaoConvertida 
+                || p.Status.OrderBy(f => f.Data).Last().Status == StatusProspeccao.Suspensa)
+                .Where(p => p.Casa == enumCasa).Count();
             double percentInfrutiferas = (double)prospeccoesInfrutiferas / ObterProspeccoesTotais(enumCasa) * 100;
 
             IndicadoresProspeccao indicadoresProspeccao = new IndicadoresProspeccao { EmpresasProspectadas = empresasProspectadas, TempoMedioContato = tempoMedioContato, PercentualInfrutiferas = percentInfrutiferas, ProspContatoInicial = prospContatoInicial };
             return Ok(JsonConvert.SerializeObject(indicadoresProspeccao));
         }
 
-        [Route("{casa}")]
+        [Route("FunilDeVendas/GerarStatusGeralProspPizza/{casa}")]
         public async Task<IActionResult> GerarStatusGeralProspPizza(string casa)
         {
             Instituto enumCasa;
@@ -177,7 +191,7 @@ namespace BaseDeProjetos.Controllers
             return Ok(JsonConvert.SerializeObject(statusGeralProspeccaoPizza));
         }
 
-        [Route("{casa}")]
+        [Route("FunilDeVendas/GerarStatusProspPropostaPizza/{casa}")]
         public async Task<IActionResult> GerarStatusProspPropostaPizza(string casa)
         {
             Instituto enumCasa;
@@ -200,10 +214,10 @@ namespace BaseDeProjetos.Controllers
         {
             return _context.Prospeccao.Select(p => new { p.Status, p.Casa })
                 .Where(p => p.Status.OrderBy(f => f.Data)
-                .First().Status != StatusProspeccao.Planejada && p.Status.Count() != 1 && p.Casa == casa)
+                .Last().Status != StatusProspeccao.Planejada && p.Casa == casa)
                 .Count();
         }
-        [Route("{casa}")]
+        [Route("FunilDeVendas/GerarStatusProspComProposta/{casa}")]
         public async Task<IActionResult> GerarStatusProspComProposta(string casa)
         {
 

--- a/BaseDeProjetos/Models/Helpers/DadosBarra.cs
+++ b/BaseDeProjetos/Models/Helpers/DadosBarra.cs
@@ -1,0 +1,13 @@
+﻿namespace BaseDeProjetos.Models.Helpers
+{
+    public class DadosBarra
+    {
+        public int ContratacaoDireta { get; set; }
+        public int EditaisInovacao { get; set; }
+        public int AgenciaFomento { get; set; }
+        public int Embrapii { get; set; }
+        public int Definir { get; set; }
+        public int ParceiroEdital { get; set; }
+        public int ANP_ANEEL { get; set; }
+    }
+}

--- a/BaseDeProjetos/Models/Helpers/GraficoBarraTipoContratacao.cs
+++ b/BaseDeProjetos/Models/Helpers/GraficoBarraTipoContratacao.cs
@@ -1,0 +1,6 @@
+﻿namespace BaseDeProjetos.Models.Helpers
+{
+    public class GraficoBarraTipoContratacao
+    {
+    }
+}

--- a/BaseDeProjetos/Models/Helpers/GraficoBarraTipoContratacao.cs
+++ b/BaseDeProjetos/Models/Helpers/GraficoBarraTipoContratacao.cs
@@ -2,5 +2,8 @@
 {
     public class GraficoBarraTipoContratacao
     {
+        public DadosBarra ContatoInicial { get; set; }
+        public DadosBarra EmDiscussao { get; set; }
+        public DadosBarra ComProposta { get; set; }
     }
 }

--- a/BaseDeProjetos/Models/Helpers/IndicadoresProspeccao.cs
+++ b/BaseDeProjetos/Models/Helpers/IndicadoresProspeccao.cs
@@ -3,8 +3,8 @@
     public class IndicadoresProspeccao
     {
         public int EmpresasProspectadas { get; set; }
-        public int TempoMedioContato { get; set; }
-        public int ProspContatoIncial { get; set; }
+        public double TempoMedioContato { get; set; }
+        public int ProspContatoInicial { get; set; }
         public double PercentualInfrutiferas { get; set; }
     }
 }

--- a/BaseDeProjetos/Models/Helpers/IndicadoresProspeccao.cs
+++ b/BaseDeProjetos/Models/Helpers/IndicadoresProspeccao.cs
@@ -1,0 +1,10 @@
+﻿namespace BaseDeProjetos.Models.Helpers
+{
+    public class IndicadoresProspeccao
+    {
+        public int EmpresasProspectadas { get; set; }
+        public int TempoMedioContato { get; set; }
+        public int ProspContatoIncial { get; set; }
+        public double PercentualInfrutiferas { get; set; }
+    }
+}

--- a/BaseDeProjetos/Models/Helpers/StatusGeralProspeccaoPizza.cs
+++ b/BaseDeProjetos/Models/Helpers/StatusGeralProspeccaoPizza.cs
@@ -1,0 +1,11 @@
+﻿namespace BaseDeProjetos.Models.Helpers
+{
+    public class StatusGeralProspeccaoPizza
+    {
+        public double PercentualCanceladas { get; set; }
+        public double PercentualConvertidas { get; set; }
+        public double PercentualNaoConvertidas { get; set; }
+        public double PercentualEmAndamento { get; set; }
+
+    }
+}

--- a/BaseDeProjetos/Models/Helpers/StatusProspPropostaIndicadores.cs
+++ b/BaseDeProjetos/Models/Helpers/StatusProspPropostaIndicadores.cs
@@ -1,0 +1,10 @@
+﻿namespace BaseDeProjetos.Models.Helpers
+{
+    public class StatusProspPropostaIndicadores
+    {
+        public double TaxaConversao { get; set; }
+        public decimal TicketMedioProsp { get; set; }
+        public int PropostasEnviadas { get; set; }
+        public int ProjetosContratados { get; set; }
+    }
+}

--- a/BaseDeProjetos/Models/Helpers/StatusProspeccoesPropostaPizza.cs
+++ b/BaseDeProjetos/Models/Helpers/StatusProspeccoesPropostaPizza.cs
@@ -2,9 +2,9 @@
 {
     public class StatusProspeccoesPropostaPizza
     {
-        public double QuantidadeEmAndamento {  get; set; }
-        public double QuantidadeConvertidas { get; set; }
-        public double QuantidadeNaoConvertidas { get; set; }
+        public int QuantidadeEmAndamento {  get; set; }
+        public int QuantidadeConvertidas { get; set; }
+        public int QuantidadeNaoConvertidas { get; set; }
 
     }
 }

--- a/BaseDeProjetos/Models/Helpers/StatusProspeccoesPropostaPizza.cs
+++ b/BaseDeProjetos/Models/Helpers/StatusProspeccoesPropostaPizza.cs
@@ -1,0 +1,10 @@
+﻿namespace BaseDeProjetos.Models.Helpers
+{
+    public class StatusProspeccoesPropostaPizza
+    {
+        public double QuantidadeEmAndamento {  get; set; }
+        public double QuantidadeConvertidas { get; set; }
+        public double QuantidadeNaoConvertidas { get; set; }
+
+    }
+}

--- a/BaseDeProjetos/Models/ViewModels/DashboardFunilViewModel.cs
+++ b/BaseDeProjetos/Models/ViewModels/DashboardFunilViewModel.cs
@@ -1,0 +1,12 @@
+﻿using BaseDeProjetos.Models.Helpers;
+
+namespace BaseDeProjetos.Models.ViewModels
+{
+    public class DashboardFunilViewModel
+    {
+        IndicadoresProspeccao IndicadoresProspeccao { get; set; }
+        StatusGeralProspeccaoPizza StatusGeralProspeccaoPizza { get; set; }
+        StatusProspeccoesPropostaPizza StatusProspeccoesPropostaPizza { get; set; }
+        StatusProspPropostaIndicadores StatusProspPropostaIndicadores { get; set; }
+    }
+}

--- a/BaseDeProjetos/Models/ViewModels/ProspeccoesViewModel.cs
+++ b/BaseDeProjetos/Models/ViewModels/ProspeccoesViewModel.cs
@@ -6,9 +6,9 @@ namespace BaseDeProjetos.Models.ViewModels
     public class ProspeccoesViewModel
     {
         public List<Prospeccao> Prospeccoes { get; set; }
-        public List<Prospeccao> ProspeccoesConcluidas { get; set; }
-        public List<Prospeccao> ProspeccoesComProposta { get; set; }
-        public List<Prospeccao> ProspeccoesPlanejadas { get; set; }
+        public int ProspeccoesConcluidas { get; set; }
+        public int ProspeccoesComProposta { get; set; }
+        public int ProspeccoesPlanejadas { get; set; }
         public List<Prospeccao> ProspeccoesGrafico { get; set; }
         public List<Prospeccao> ProspeccoesAgregadas { get; set; }
         public List<Prospeccao> ProspeccoesAtivas { get; set; }

--- a/BaseDeProjetos/Models/ViewModels/ProspeccoesViewModel.cs
+++ b/BaseDeProjetos/Models/ViewModels/ProspeccoesViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using BaseDeProjetos.Helpers;
+using BaseDeProjetos.Models.Helpers;
 using System.Collections.Generic;
 
 namespace BaseDeProjetos.Models.ViewModels

--- a/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
@@ -3,7 +3,6 @@
 @using BaseDeProjetos.Models.Enums;
 @using BaseDeProjetos.Models.ViewModels;
 @using Microsoft.AspNetCore.Http
-    using BaseDeProjetos.Models.Enums;
 @{
     ViewData["Title"] = "Funil de Vendas";
 

--- a/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/Index.cshtml
@@ -21,6 +21,10 @@
     List<Instituto> institutos = new List<Instituto>((Instituto[])Enum.GetValues(typeof(Instituto))).Where(i => i != Instituto.Super).ToList();
 }
 
+<script>
+    var casa = "@casa"
+</script>
+
 <partial name="Header" view-data="@ViewData" />
 <style>
     .button-flash {

--- a/BaseDeProjetos/Views/FunilDeVendas/graph_funil.cshtml
+++ b/BaseDeProjetos/Views/FunilDeVendas/graph_funil.cshtml
@@ -1,8 +1,9 @@
 ﻿@model ProspeccoesViewModel
 @using System
 @using BaseDeProjetos.Helpers
-@using BaseDeProjetos.Models.Enums;
-@using BaseDeProjetos.Models.ViewModels;
+@using BaseDeProjetos.Models.Enums
+@using BaseDeProjetos.Models.ViewModels
+<script type="text/javascript" src="~/js/FunildeVendas/graficosDashboardFunil.js"></script>
 <style>
     .center {
         display: flex;
@@ -108,23 +109,23 @@
                 </div>
                 <div class="app-card-body row text-center p-3 p-lg-4">
                     <div class="col-12">
-                        <!--[Iury] IDs da checkbox \/ -->
-                    <h1 id="CheckboxProspAtivas1" class="display-3">@numEmpresas</h1>
+                        <!--[Iury] sIDs da checkbox \/ -->
+                        <h1 id="EmpresasProspectadas" class="display-3"></h1>
                         <small id="CheckboxProspAtivas2">Número de empresas prospectadas</small>
                         <hr />
                     </div>
                     <div class="col-4">
-                        <h4 id="CheckboxProspAtivas7">@Math.Abs(DiferencaTodas.Days) dias</h4>
+                        <h4 id="TempoMedioContato"></h4>
                         <small id="CheckboxProspAtivas10">Tempo médio entre o primeiro contato e a emissão da
                             proposta</small>
                     </div>
                     <div class="col-4">
                         <!--[Iury] IDs da checkbox \/ -->
-                    <h4 id="CheckboxProspAtivas4">@Model.ProspeccoesNaoPlanejadas.Count()</h4>
+                        <h4 id="ProspContatoInicial"></h4>
                         <small id="CheckboxProspAtivas3">Contatos iniciais de prospecção</small>
                     </div>
                     <div class="col-4">
-                        <h4> @taxaInfrutiferas.ToString("P2")</h4>
+                        <h4 id="PercentualInfrutiferas"></h4>
                         <small>
                             Percentual de prospecções infrutíferas
                         </small>
@@ -162,34 +163,26 @@
             </div>
             <div class="app-card-body row text-center p-3 p-lg-4">
                 <div class="col-12">
-                    <h1 class="display-3">@taxaConversao.ToString("P2")</h1>
+                    <h1 class="display-3" id="TaxaConversao"></h1>
                     <small>
                         Taxa de conversão de prospecções
                     </small>
                     <hr />
                 </div>
                 <div class="col-4">
-                    <!-- Quando transformar em calculado, remover o R$-->
-                    @if (valorTotalPropostas > 0)
-                    {
-                        <h4 id="CheckboxProspAtivas5">@valorTotalPropostas.ToString("C2")</h4>
-                    }
-                    else
-                    {
-                        <h4 id="CheckboxProspAtivas5">R$ ---</h4>
-                    }
+                    <h4 id="TicketMedioProsp"></h4>
                     <small id="CheckboxProspAtivas8">
                         Ticket médio das prospecções
                     </small>
                 </div>
                 <div class="col-4">
-                    <h4 id="CheckboxProspAtivas6">@numPropostas</h4>
+                    <h4 id="PropostasEnviadas"></h4>
                     <small id="CheckboxProspAtivas9">
                         Propostas comerciais enviadas
                     </small>
                 </div>
                 <div class="col-4">
-                    <h4>@numConvertidas</h4>
+                    <h4 id="ProjetosContratados"></h4>
                     <small>
                         Projetos contratados
                     </small>
@@ -200,203 +193,6 @@
 
     </div>
 
-
-    <!-- Gráfico de Fomentos por status-->
-    <script type="text/javascript">
-
-        const seriespadrao = [
-            { name: 'Contratação Direta', data: [@contagem["ContratacaoDireta_ContatoInicial"], @contagem["ContratacaoDireta_Discussao_EsbocoProjeto"], @contagem["ContratacaoDireta_ComProposta"]] },
-            { name: 'Editais de Inovação SESI/SENAI', data: [@contagem["EditalInovacao_ContatoInicial"], @contagem["EditalInovacao_Discussao_EsbocoProjeto"], @contagem["EditalInovacao_ComProposta"]] },
-            { name: 'Agências de Fomento', data: [@contagem["AgenciaFomento_ContatoInicial"], @contagem["AgenciaFomento_Discussao_EsbocoProjeto"], @contagem["AgenciaFomento_ComProposta"] ] },
-            { name: 'Embrapii', data: [@contagem["Embrapii_ContatoInicial"], @contagem["Embrapii_Discussao_EsbocoProjeto"], @contagem["Embrapii_ComProposta"] ] },
-            { name: 'A definir', data: [@contagem["Indefinida_ContatoInicial"], @contagem["Indefinida_Discussao_EsbocoProjeto"], @contagem["Indefinida_ComProposta"] ] },
-            { name: 'Parceiros de Edital', data: [@contagem["Parceiro_ContatoInicial"], @contagem["Parceiro_Discussao_EsbocoProjeto"], @contagem["Parceiro_ComProposta"] ] },
-            { name: 'ANP/ANEEL', data: [@contagem["ANP_ContatoInicial"], @contagem["ANP_Discussao_EsbocoProjeto"], @contagem["ANP_ComProposta"] ] }
-        ];
-
-        var seriesativas = [
-            { name: 'Contratação Direta', data: [@contagem["ContratacaoDireta_ContatoInicial_Ativas"], @contagem["ContratacaoDireta_Discussao_EsbocoProjeto_Ativas"], @contagem["ContratacaoDireta_ComProposta_Ativas"]] },
-            { name: 'Editais de Inovação SESI/SENAI', data: [@contagem["EditalInovacao_ContatoInicial_Ativas"], @contagem["EditalInovacao_Discussao_EsbocoProjeto_Ativas"], @contagem["EditalInovacao_ComProposta_Ativas"]] },
-            { name: 'Agências de Fomento', data: [@contagem["AgenciaFomento_ContatoInicial_Ativas"], @contagem["AgenciaFomento_Discussao_EsbocoProjeto_Ativas"], @contagem["AgenciaFomento_ComProposta_Ativas"] ] },
-            { name: 'Embrapii', data: [@contagem["Embrapii_ContatoInicial_Ativas"], @contagem["Embrapii_Discussao_EsbocoProjeto_Ativas"], @contagem["Embrapii_ComProposta_Ativas"] ] },
-            { name: 'A definir', data: [@contagem["Indefinida_ContatoInicial_Ativas"], @contagem["Indefinida_Discussao_EsbocoProjeto_Ativas"], @contagem["Indefinida_ComProposta_Ativas"] ] },
-            { name: 'Parceiros de Edital', data: [@contagem["Parceiro_ContatoInicial_Ativas"], @contagem["Parceiro_Discussao_EsbocoProjeto_Ativas"], @contagem["Parceiro_ComProposta_Ativas"] ] },
-            { name: 'ANP/ANEEL', data: [@contagem["ANP_ContatoInicial_Ativas"], @contagem["ANP_Discussao_EsbocoProjeto_Ativas"], @contagem["ANP_ComProposta_Ativas"] ] }
-        ];
-
-        var chart1 = Highcharts.chart('funil', {
-            chart: { type: 'column', allowMutatingData: false },
-            title: { text: null },
-            xAxis: { categories: ["Contato inicial", "Em discussão", "Com Proposta", "Convertida",], },
-            yAxis: { min: 0, title: { text: 'Ocorrências' } },
-            tooltip: {
-                headerFormat: '<span style="font-size:10px">{point.key}</span><table>',
-                pointFormat: '<tr><td style="color:{series.color};padding:0">{series.name}: </td>' +
-                    '<td style="padding:0"><b>{point.y:.1f} prospecções</b></td></tr>',
-                footerFormat: '</table>',
-                shared: true,
-                useHTML: true
-            },
-            plotOptions: { column: { pointPadding: 0.2, borderWidth: 0 } },
-            series: seriespadrao
-        })
-
-        <!-- Pizzas -->
-
-        var pizzaDesistencia = Highcharts.chart('pizza_desistencia', {
-            chart: {
-                plotBackgroundColor: null,
-                plotBorderWidth: null,
-                plotShadow: false,
-                type: 'pie'
-            },
-            title: {
-                text: null
-            },
-            tooltip: {
-                pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'
-            },
-            accessibility: {
-                point: {
-                    valueSuffix: '%'
-                }
-            },
-            plotOptions: {
-                pie: {
-                    allowPointSelect: true,
-                    cursor: 'pointer',
-                    dataLabels: {
-                        enabled: true,
-                        format: '<b>{point.name}</b>: {point.percentage:.1f} %'
-                    }
-                }
-            },
-            series: [{
-                size: '60%',
-                name: 'Propostas',
-                colorByPoint: true,
-                data: [{
-                    name: 'Em andamento',
-                    y: @numProspeccoesEmAndamento,
-                    drilldown: 'andamento'
-                }, {
-                    name: 'Convertidas',
-                    y: @numConvertidas,
-                    drilldown: null
-                },
-                {
-                    name: 'Não Convertidas',
-                    y: @numNaoConvertidas,
-                    drilldown: null
-                },
-                {
-                    name: 'Canceladas',
-                    y: @numCanceladas,
-                    drilldown: null
-                },
-                ],
-            }],
-
-            drilldown: {
-                series: [
-                    {
-                        id: 'andamento',
-                        data: [
-                            ["Ativas",
-        @(numProspeccoesEmAndamento)],
-                            ["Com proposta",
-        @(numPropostas)]
-                        ]
-                    }]
-            }
-        });
-
-        var pizzaConversao = Highcharts.chart('pizza_conversao', {
-            chart: {
-                plotBackgroundColor: null,
-                plotBorderWidth: null,
-                plotShadow: false,
-                type: 'pie'
-            },
-            title: {
-                text: 'Status de Prospecções com propostas'
-            },
-            tooltip: {
-                pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'
-            },
-            accessibility: {
-                point: {
-                    valueSuffix: '%'
-                }
-            },
-            plotOptions: {
-                pie: {
-                    allowPointSelect: true,
-                    cursor: 'pointer',
-                    dataLabels: {
-                        enabled: true,
-                        format: '<b>{point.name}</b>: {point.y} prospecções'
-                    }
-                }
-            },
-            series: [{
-                size: '60%',
-                name: 'Propostas',
-                colorByPoint: true,
-                data: [{
-                    name: 'Em andamento',
-                    y: @(numProspeccoesEmAndamentoComProposta),
-                }, {
-                    name: 'Convertidas',
-                    y: @numConvertidas
-                }, {
-                    name: 'Não convertidas',
-                    y: @numNaoConvertidas
-                }]
-            }]
-        });
-
-    </script>
-
-    <script type="text/javascript">
-        function alterarTextos(statusfiltro) {
-            if (!statusfiltro) {
-                document.getElementById("CheckboxProspAtivas2").textContent = "Número de empresas prospectadas";
-                document.getElementById("CheckboxProspAtivas3").textContent = "Contatos iniciais de prospecção";
-                document.getElementById("CheckboxProspAtivas8").textContent = "Ticket médio das prospecções";
-                document.getElementById("CheckboxProspAtivas9").textContent = "Propostas comerciais enviadas";
-                document.getElementById("CheckboxProspAtivas10").textContent = "Tempo médio entre o primeiro contato e a emissão da proposta";
-            }
-            else {
-                document.getElementById("CheckboxProspAtivas2").textContent += " (Ativas)";
-                document.getElementById("CheckboxProspAtivas3").textContent += " (Ativas)";
-                document.getElementById("CheckboxProspAtivas8").textContent += " (Ativas)";
-                document.getElementById("CheckboxProspAtivas9").textContent += " (Ativas)";
-                document.getElementById("CheckboxProspAtivas10").textContent += " (Ativas)";
-            }
-        }
-
-
-        function marcada() {
-            if (document.getElementById("caixaSelecaoAtivas").checked) {
-                document.getElementById("CheckboxProspAtivas1").innerHTML = @numEmpresasAtivas;
-                document.getElementById("CheckboxProspAtivas4").textContent = @Model.ProspeccoesAtivas.Count();
-                document.getElementById("CheckboxProspAtivas5").textContent = "@valorAtivasString";
-                document.getElementById("CheckboxProspAtivas6").textContent = @numPropostasAtivas;
-                document.getElementById("CheckboxProspAtivas7").textContent = "@Math.Abs(DiferencaAtivas.Days) dias";
-                alterarTextos(true)
-                chart1.update({ series: seriesativas });
-            } else {
-                document.getElementById("CheckboxProspAtivas1").innerHTML = @numEmpresas;
-                document.getElementById("CheckboxProspAtivas4").textContent = @Model.ProspeccoesNaoPlanejadas.Count();
-                document.getElementById("CheckboxProspAtivas5").textContent = "@valorString";
-                document.getElementById("CheckboxProspAtivas6").textContent = @numPropostas;
-                document.getElementById("CheckboxProspAtivas7").textContent = "@Math.Abs(DiferencaTodas.Days) dias";
-                alterarTextos(false)
-                chart1.update({ series: seriespadrao });
-            }
-        }
-    </script>
 }
 else
 {

--- a/BaseDeProjetos/wwwroot/js/FunildeVendas/graficosDashboardFunil.js
+++ b/BaseDeProjetos/wwwroot/js/FunildeVendas/graficosDashboardFunil.js
@@ -135,6 +135,49 @@ function preencherDadosStatusGeralProspPizza(dadosProsp) {
     });
 }
 
+async function fetchDadosGraficoBarraTipoContratacao() {
+    let fetchedData;
+    await fetch("/FunildeVendas/GerarGraficoBarraTipoContratacao")
+        .then(res => res.json())
+        .then(data => fetchedData = data)
+        .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
+    return fetchedData;
+}
+function preencherDadosGraficoBarraTipoContratacao(dadosProsp) {
+    console.log(dadosProsp)
+
+    let comProposta = "ComProposta"
+    let contatoInicial = "ContatoInicial"
+    let emDiscussao = "EmDiscussao"
+
+    const seriespadrao = [
+        { name: 'Contratação Direta', data: [dadosProsp[contatoInicial]["ContratacaoDireta"], dadosProsp[emDiscussao]["ContratacaoDireta"], dadosProsp[comProposta]["ContratacaoDireta"]] },
+        { name: 'Editais de Inovação SESI/SENAI', data: [dadosProsp[contatoInicial]["EditaisInovacao"], dadosProsp[emDiscussao]["EditaisInovacao"], dadosProsp[comProposta]["EditaisInovacao"]] },
+        { name: 'Agências de Fomento', data: [dadosProsp[contatoInicial]["AgenciaFomento"], dadosProsp[emDiscussao]["AgenciaFomento"], dadosProsp[comProposta]["AgenciaFomento"]] },
+        { name: 'Embrapii', data: [dadosProsp[contatoInicial]["Embrapii"], dadosProsp[emDiscussao]["Embrapii"], dadosProsp[comProposta]["Embrapii"]] },
+        { name: 'A definir', data: [dadosProsp[contatoInicial]["Definir"], dadosProsp[emDiscussao]["Definir"], dadosProsp[comProposta]["Definir"]] },
+        { name: 'Parceiros de Edital', data: [dadosProsp[contatoInicial]["ParceiroEdital"], dadosProsp[emDiscussao]["ParceiroEdital"], dadosProsp[comProposta]["ParceiroEdital"]["Parceiro_ComProposta"]] },
+        { name: 'ANP/ANEEL', data: [dadosProsp[contatoInicial]["ANP_ANEEL"], dadosProsp[emDiscussao]["ANP_ANEEL"], dadosProsp[comProposta]["ANP_ANEEL"]] }
+    ];
+    
+    let chart1 = Highcharts.chart('funil', {
+        chart: { type: 'column', allowMutatingData: false },
+        title: { text: null },
+        xAxis: { categories: ["Contato inicial", "Em discussão", "Com Proposta"], },
+        yAxis: { min: 0, title: { text: 'Ocorrências' } },
+        tooltip: {
+            headerFormat: '<span style="font-size:10px">{point.key}</span><table>',
+            pointFormat: '<tr><td style="color:{series.color};padding:0">{series.name}: </td>' +
+                '<td style="padding:0"><b>{point.y:.1f} prospecções</b></td></tr>',
+            footerFormat: '</table>',
+            shared: true,
+            useHTML: true
+        },
+        plotOptions: { column: { pointPadding: 0.2, borderWidth: 0 } },
+        series: seriespadrao
+    })
+}
+
 async function fetchDadosStatusProspeccoesPropostaPizza() {
     let fetchedData;
     await fetch("/FunildeVendas/GerarStatusProspPropostaPizza")
@@ -223,6 +266,14 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(data => {
             if (data) {
                 preencherDadosStatusProspeccoesPropostaPizza(data);
+            } else {
+                console.error("Não há dados para exibir no dashboard.");
+            }
+        });
+    fetchDadosGraficoBarraTipoContratacao()
+        .then(data => {
+            if (data) {
+                preencherDadosGraficoBarraTipoContratacao(data);
             } else {
                 console.error("Não há dados para exibir no dashboard.");
             }

--- a/BaseDeProjetos/wwwroot/js/FunildeVendas/graficosDashboardFunil.js
+++ b/BaseDeProjetos/wwwroot/js/FunildeVendas/graficosDashboardFunil.js
@@ -1,6 +1,6 @@
 ﻿async function fetchDadosIndicadoresProspeccao() {
     let fetchedData;
-    await fetch("/FunildeVendas/GerarIndicadoresProsp")
+    await fetch(`/FunildeVendas/GerarIndicadoresProsp/${casa}`)
         .then(res => res.json())
         .then(data => fetchedData = data)
         .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
@@ -35,7 +35,7 @@ function preencherDadosIndicadoresProsp(dadosProsp) {
 
 async function fetchDadosStatusProspComProposta() {
     let fetchedData;
-    await fetch("/FunildeVendas/GerarStatusProspComProposta")
+    await fetch(`/FunildeVendas/GerarStatusProspComProposta/${casa}`)
         .then(res => res.json())
         .then(data => fetchedData = data)
         .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
@@ -71,7 +71,7 @@ function preencherDadosStatusProspComProposta(dadosProsp) {
 
 async function fetchDadosStatusGeralProspPizza() {
     let fetchedData;
-    await fetch("/FunildeVendas/GerarStatusGeralProspPizza")
+    await fetch(`/FunildeVendas/GerarStatusGeralProspPizza/${casa}`)
         .then(res => res.json())
         .then(data => fetchedData = data)
         .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
@@ -137,7 +137,7 @@ function preencherDadosStatusGeralProspPizza(dadosProsp) {
 
 async function fetchDadosGraficoBarraTipoContratacao() {
     let fetchedData;
-    await fetch("/FunildeVendas/GerarGraficoBarraTipoContratacao")
+    await fetch(`/FunildeVendas/GerarGraficoBarraTipoContratacao/${casa}`)
         .then(res => res.json())
         .then(data => fetchedData = data)
         .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
@@ -180,7 +180,7 @@ function preencherDadosGraficoBarraTipoContratacao(dadosProsp) {
 
 async function fetchDadosStatusProspeccoesPropostaPizza() {
     let fetchedData;
-    await fetch("/FunildeVendas/GerarStatusProspPropostaPizza")
+    await fetch(`/FunildeVendas/GerarStatusProspPropostaPizza/${casa}`)
         .then(res => res.json())
         .then(data => fetchedData = data)
         .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))

--- a/BaseDeProjetos/wwwroot/js/FunildeVendas/graficosDashboardFunil.js
+++ b/BaseDeProjetos/wwwroot/js/FunildeVendas/graficosDashboardFunil.js
@@ -1,0 +1,233 @@
+﻿async function fetchDadosIndicadoresProspeccao() {
+    let fetchedData;
+    await fetch("/FunildeVendas/GerarIndicadoresProsp")
+        .then(res => res.json())
+        .then(data => fetchedData = data)
+        .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
+    return fetchedData;
+}
+
+function preencherDadosIndicadoresProsp(dadosProsp) {
+    let identificadores = ["EmpresasProspectadas", "TempoMedioContato", "ProspContatoInicial", "PercentualInfrutiferas"]
+    identificadores.forEach(identificador => {
+
+
+        switch (identificador) {
+            case 'EmpresasProspectadas':
+                document.getElementById(identificador).innerText = dadosProsp[identificador]
+                break
+            case 'TempoMedioContato':
+                document.getElementById(identificador).innerText = dadosProsp[identificador].toFixed(1)
+                break
+            case 'ProspContatoInicial':
+                document.getElementById(identificador).innerText = dadosProsp[identificador]
+                break
+            case 'PercentualInfrutiferas':
+                document.getElementById(identificador).innerText = dadosProsp[identificador].toFixed(2) + '%'
+                break
+            default:
+                console.log("erro")
+
+
+        }
+    })
+}
+
+async function fetchDadosStatusProspComProposta() {
+    let fetchedData;
+    await fetch("/FunildeVendas/GerarStatusProspComProposta")
+        .then(res => res.json())
+        .then(data => fetchedData = data)
+        .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
+    return fetchedData;
+}
+
+function preencherDadosStatusProspComProposta(dadosProsp) {
+    let identificadores = ["TaxaConversao", "TicketMedioProsp", "PropostasEnviadas", "ProjetosContratados"]
+    identificadores.forEach(identificador => {
+
+
+        switch (identificador) {
+            case 'TaxaConversao':
+                document.getElementById(identificador).innerText = dadosProsp[identificador].toFixed(2) + '%'
+                break
+            case 'TicketMedioProsp':
+                document.getElementById(identificador).innerText = dadosProsp[identificador].toLocaleString('pt-BR', { style: 'currency', currency: 'BRL'})
+                break
+            case 'PropostasEnviadas':
+                document.getElementById(identificador).innerText = dadosProsp[identificador]
+                break
+            case 'ProjetosContratados':
+                document.getElementById(identificador).innerText = dadosProsp[identificador]
+                break
+            default:
+                console.log("erro")
+
+
+        }
+    })
+}
+
+
+async function fetchDadosStatusGeralProspPizza() {
+    let fetchedData;
+    await fetch("/FunildeVendas/GerarStatusGeralProspPizza")
+        .then(res => res.json())
+        .then(data => fetchedData = data)
+        .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
+    return fetchedData;
+}
+
+function preencherDadosStatusGeralProspPizza(dadosProsp) {
+    let pizzaDesistencia = Highcharts.chart('pizza_desistencia', {
+        chart: {
+            plotBackgroundColor: null,
+            plotBorderWidth: null,
+            plotShadow: false,
+            type: 'pie'
+        },
+        title: {
+            text: null
+        },
+        tooltip: {
+            pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'
+        },
+        accessibility: {
+            point: {
+                valueSuffix: '%'
+            }
+        },
+        plotOptions: {
+            pie: {
+                allowPointSelect: true,
+                cursor: 'pointer',
+                dataLabels: {
+                    enabled: true,
+                    format: '<b>{point.name}</b>: {point.percentage:.1f} %'
+                }
+            }
+        },
+        series: [{
+            size: '60%',
+            name: 'Propostas',
+            colorByPoint: true,
+            data: [{
+                name: 'Em andamento',
+                y: dadosProsp['PercentualEmAndamento'],
+                drilldown: null
+            }, {
+                name: 'Convertidas',
+                y: dadosProsp['PercentualConvertidas'],
+                drilldown: null
+            },
+            {
+                name: 'Não Convertidas',
+                y: dadosProsp['PercentualNaoConvertidas'],
+                drilldown: null
+            },
+            {
+                name: 'Canceladas',
+                y: dadosProsp['PercentualCanceladas'],
+                drilldown: null
+            },
+            ],
+        }],
+    });
+}
+
+async function fetchDadosStatusProspeccoesPropostaPizza() {
+    let fetchedData;
+    await fetch("/FunildeVendas/GerarStatusProspPropostaPizza")
+        .then(res => res.json())
+        .then(data => fetchedData = data)
+        .catch(err => console.error(`Houve um erro ao obter os dados dos indicadores: ${err}`))
+    return fetchedData;
+}
+function preencherDadosStatusProspeccoesPropostaPizza(dadosProsp) {
+
+    let pizzaConversao = Highcharts.chart('pizza_conversao', {
+        chart: {
+            plotBackgroundColor: null,
+            plotBorderWidth: null,
+            plotShadow: false,
+            type: 'pie'
+        },
+        title: {
+            text: 'Status de Prospecções com propostas'
+        },
+        tooltip: {
+            pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'
+        },
+        accessibility: {
+            point: {
+                valueSuffix: '%'
+            }
+        },
+        plotOptions: {
+            pie: {
+                allowPointSelect: true,
+                cursor: 'pointer',
+                dataLabels: {
+                    enabled: true,
+                    format: '<b>{point.name}</b>: {point.y} prospecções'
+                }
+            }
+        },
+        series: [{
+            size: '60%',
+            name: 'Propostas',
+            colorByPoint: true,
+            data: [{
+                name: 'Em andamento',
+                y: dadosProsp['QuantidadeEmAndamento'],
+            }, {
+                name: 'Convertidas',
+                y: dadosProsp['QuantidadeConvertidas'],
+            }, {
+                name: 'Não convertidas',
+                y: dadosProsp['QuantidadeNaoConvertidas'],
+            }]
+        }]
+    });
+
+}
+
+
+
+document.addEventListener("DOMContentLoaded", () => {
+    fetchDadosIndicadoresProspeccao()
+        .then(data => {
+            if (data) {
+                preencherDadosIndicadoresProsp(data);
+            } else {
+                console.error("Não há dados para exibir no dashboard.");
+            }
+        });
+    fetchDadosStatusProspComProposta()
+        .then(data => {
+            if (data) {
+                preencherDadosStatusProspComProposta(data);
+            } else {
+                console.error("Não há dados para exibir no dashboard.");
+            }
+        });
+    fetchDadosStatusGeralProspPizza()
+        .then(data => {
+            if (data) {
+                preencherDadosStatusGeralProspPizza(data);
+            } else {
+                console.error("Não há dados para exibir no dashboard.");
+            }
+        });
+    fetchDadosStatusProspeccoesPropostaPizza()
+        .then(data => {
+            if (data) {
+                preencherDadosStatusProspeccoesPropostaPizza(data);
+            } else {
+                console.error("Não há dados para exibir no dashboard.");
+            }
+        });
+});
+
+
+


### PR DESCRIPTION
O intuito desse PR é separar a lógica dos gráficos da dashboard do Funil de Vendas a fim de separar a responsabilidade do gráfico do Index e ao mesmo tempo facilitar uma refatoração futura.