### PR TITLE
Refazer página de confirmação de email e registro

### DIFF
--- a/BaseDeProjetos/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
+++ b/BaseDeProjetos/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
@@ -2,12 +2,18 @@
 @model ConfirmEmailModel
 @{
     ViewData["Title"] = "Confirme seu e-mail";
-    ViewData["Mensagem"] = "Verifique sua caixa de entrada para ver se recebeu o e-mail de confirmação de conta.";
+    ViewData["Mensagem"] = "Verifique a sua caixa de entrada (ou spam) para ver se recebeu o e-mail de confirmação de conta.";
 }
 
-<div class="jumbotron">
-    <h1>@ViewData["Title"]</h1>
-    <p>
-        @ViewData["Mensagem"]
-    </p>
+<div class="container">
+    <div class="text-center">
+        <h2><i class="bi bi-envelope-check-fill"></i> @ViewData["Title"]</h2>
+        <p>
+            @ViewData["Mensagem"]
+        </p>
+        <div class="mt-3 mb-3">
+            <a href="/" class="btn app-btn-secondary">Página Principal</a>
+            <a asp-area="Identity" asp-page="/Account/Login" class="btn app-btn-primary">Login</a>
+        </div>
+    </div>
 </div>

--- a/BaseDeProjetos/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/BaseDeProjetos/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -13,7 +13,7 @@
                 <p>Estamos trabalhando no nosso serviço de email.</p>
                 <div>Enquanto isso, clique abaixo para confirmar o registro da sua conta.</div>
             </div>
-            <p>Clique <a id="confirm-link" href="@Model.EmailConfirmationUrl">aqui</a> para confirmar o seu registro</p>
+            <p>Clique <a id="confirm-link" href="@Model.EmailConfirmationUrl">aqui</a> para confirmar o seu registro.</p>
         </div>
     }
     else

--- a/BaseDeProjetos/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/BaseDeProjetos/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -1,22 +1,25 @@
 ﻿@page
 @model RegisterConfirmationModel
 @{
-    ViewData["Title"] = "Register confirmation";
+    ViewData["Title"] = "Confirmação de conta";
 }
 
-<h1>@ViewData["Title"]</h1>
-@{
-    if (@Model.DisplayConfirmAccountLink)
+<div class="container">
+    @if (Model.DisplayConfirmAccountLink)
     {
-        <p>
-            This app does not currently have a real email sender registered, see <a href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
-            Normally this would be emailed: <a id="confirm-link" href="@Model.EmailConfirmationUrl">Click here to confirm your account</a>
-        </p>
+        <div class="text-center">
+            <h2>Confirme a sua conta!</h2>
+            <div class="alert alert-warning" role="alert">
+                <p>Estamos trabalhando no nosso serviço de email.</p>
+                <div>Enquanto isso, clique abaixo para confirmar o registro da sua conta.</div>
+            </div>
+            <p>Clique <a id="confirm-link" href="@Model.EmailConfirmationUrl">aqui</a> para confirmar o seu registro</p>
+        </div>
     }
     else
     {
-        <p>
-            Please check your email to confirm your account.
-        </p>
+        <div class="text-center">
+            <p>Por favor, verifique a sua caixa de email para confirmar a sua conta.</p>
+        </div>
     }
-}
+</div>


### PR DESCRIPTION
O intuito de PR é melhorar o layout da página de confirmação de cadastro. Para não só informar ao usuário sobre o status atual do sistema de email (fora do ar) mas também ficar mais óbvio como ele deve prosseguir.
![firefox_pR67OWyOy6](https://github.com/SESIDEV/BaseDeProjetos/assets/114450012/81d71656-7ced-414e-94fe-9b3802028441)
![image](https://github.com/SESIDEV/BaseDeProjetos/assets/114450012/1427f169-1ec2-43ed-a04e-a2f842cfb0db)
